### PR TITLE
Fix project typos and add register integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=yourpassword
-DB_NAME=spent_track
+DB_NAME=spend_track
 ```
 
 > PostgreSQL is used as the default DB engine.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "send-track-api",
+  "name": "spend-track-api",
   "version": "1.0.0",
   "description": "API to track all your expenses efficiently and effectively.",
   "main": "dist/src/index.js",

--- a/src/config/di.ts
+++ b/src/config/di.ts
@@ -14,9 +14,13 @@ import { initDB } from './database';
 // load environment variables from .env file
 dotenv.config();
 
-const jwtSecret = process.env.JWT_SECRET;
+let jwtSecret = process.env.JWT_SECRET;
 if (typeof jwtSecret !== 'string' || jwtSecret.trim() === '') {
-  throw new Error('JWT_SECRET must be a non-empty string');
+  if (process.env.NODE_ENV === 'test') {
+    jwtSecret = 'test-secret';
+  } else {
+    throw new Error('JWT_SECRET must be a non-empty string');
+  }
 }
 
 export let authService: AuthService;

--- a/tests/integration/user/register.test.ts
+++ b/tests/integration/user/register.test.ts
@@ -1,3 +1,50 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { randomUUID } from 'crypto';
+import request from 'supertest';
+import app from '../../../src/app';
+import { AppDataSource } from '../../../src/infrastructure/database/DataSource';
+import { UserModel } from '../../../src/infrastructure/database/models/UserModel';
+import { TestEnvironmentInstance } from '../shared/testEnvironment';
+
+const testEnv = TestEnvironmentInstance;
+const ENDPOINT_ROUTE = '/api/users/register';
+
 describe('Register endpoint', () => {
-  it.todo('should register a user');
+  let email: string;
+
+  beforeAll(async () => {
+    await testEnv.init();
+  }, 15000);
+
+  afterAll(async () => {
+    await testEnv.finish();
+  });
+
+  beforeEach(async () => {
+    email = `test-${randomUUID()}@gmail.com`;
+    await testEnv.queryRunner?.startTransaction();
+  });
+
+  afterEach(async () => {
+    await AppDataSource.manager.delete(UserModel, { email });
+    await testEnv.queryRunner?.rollbackTransaction();
+  });
+
+  it('should register a user', async () => {
+    const name = 'Test User';
+    const password = 'test_password';
+
+    const response = await request(app).post(ENDPOINT_ROUTE).send({
+      name,
+      email,
+      password,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body.data).toHaveProperty('id');
+    expect(response.body.data).toMatchObject({ name, email });
+  });
 });
+


### PR DESCRIPTION
## Summary
- fix package name typo
- document correct DB_NAME env var
- provide default JWT secret in tests
- add integration test for user registration

## Testing
- `npm test` *(fails: QueryRunner not initialized / Driver not Connected)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68bef3ef6170832ab80ae6840e7181db)